### PR TITLE
Fixing Vnm interface

### DIFF
--- a/common/locale/vi_VN/LC_MESSAGES/messages.po
+++ b/common/locale/vi_VN/LC_MESSAGES/messages.po
@@ -54,7 +54,7 @@ msgid "Internet Connection Error"
 msgstr "Lỗi kết nối mạng"
 
 msgid "Browse Dictionary"
-msgstr "Duyệt thư mục"
+msgstr "Tra từ bằng kí tự Pāḷi Roman"
 
 msgid "Input Word Explanation Preview"
 msgstr "Hiện bảng giải nghĩa ngắn gọn"
@@ -99,7 +99,7 @@ msgid "Burmese First"
 msgstr "Tiếng Miến trước"
 
 msgid "Keyboard"
-msgstr "Bàn phím"
+msgstr "Bàn phím ảo"
 
 msgid "Pali Tipitaka"
 msgstr "Tam tạng Pāḷi"
@@ -111,7 +111,7 @@ msgid "Dictionary"
 msgstr "Từ điển"
 
 msgid "Browse"
-msgstr "Rà duyệt"
+msgstr "Xem các thư mục"
 
 msgid "Loading"
 msgstr "Đang lấy dữ liệu"
@@ -132,7 +132,7 @@ msgid "Excerpt"
 msgstr "Trích dẫn"
 
 msgid "Contrast Reading"
-msgstr "So sánh"
+msgstr "Đối chiếu song ngữ"
 
 msgid "Translation of This Pāḷi Text"
 msgstr "Bản dịch của văn bản Pāḷi này"


### PR DESCRIPTION
I fixed some imperfect points here.

Besides, the Vnm interface still has some problem as below:
1. On the Canon site, the main menu's titles are having large space. It should be short space like the Dictionaries site. (For example: "Trang chính". Not "Trang   chính"
1. The Vnm interface should has full name as: "Tiếng Việt" instead of "Việt". And once being inside it, the menu should be: "Tiếng Anh" instead of "English"; "Tiếng Pháp" instead of "Francais"; "Tiếng Hoa (Đài Loan)" instead of 中文 (繁體); "Tiếng Hoa (Đại Lục)" instead of 中文 (简体)

Thank you!
